### PR TITLE
Make `Address::secondaryAddress` public

### DIFF
--- a/src/Faker/Address.php
+++ b/src/Faker/Address.php
@@ -65,7 +65,14 @@ abstract class Address extends Faker
         return self::numerify(implode(' ', $chunks));
     }
 
-    private static function secondaryAddress()
+    /**
+     * Generate a random secondary address.
+     *
+     * @access public
+     * @static
+     * @return string Secondary address
+     */
+    public static function secondaryAddress()
     {
         return self::numerify(self::pickOne(array('Apt. ###', 'Suite ###')));
     }


### PR DESCRIPTION
I have found myself in need of this:

``` php
$someObject->address1 = \Faker\Address::streetAddress();
$someObject->address2 = \Faker\Address::secondaryAddress();
```

But could not because `secondaryAddress` was private.
